### PR TITLE
Don't default to using an empty dependency record when comparing cached data

### DIFF
--- a/lib/licensed/command/cache.rb
+++ b/lib/licensed/command/cache.rb
@@ -35,10 +35,10 @@ module Licensed
 
                 # try to load existing record from disk
                 # or default to a blank record
-                cached_record = Licensed::DependencyRecord.read(filename) || Licensed::DependencyRecord.new
+                cached_record = Licensed::DependencyRecord.read(filename)
 
                 # cached version string exists and did not change, no need to re-cache
-                has_version = !cached_record["version"].nil? && !cached_record["version"].empty?
+                has_version = cached_record && !cached_record["version"].nil? && !cached_record["version"].empty?
                 if !force && has_version && version == cached_record["version"]
                   @config.ui.info "    Using #{name} (#{version})"
                   next

--- a/lib/licensed/dependency_record.rb
+++ b/lib/licensed/dependency_record.rb
@@ -70,8 +70,6 @@ module Licensed
     # Returns whether two records match based on their contents
     def matches?(other)
       return false unless other.is_a?(DependencyRecord)
-      return false if self.content.nil?
-
       self.content_normalized == other.content_normalized
     end
   end


### PR DESCRIPTION
Similar to https://github.com/github/licensed/pull/123 for the 1.x releases, this removes the usage of an empty default cached record to compare against.  This has the potential to overwrite real dependency data found from enumerating a projects dependencies.

It also ends up simplifying the content matching a bit by removing custom logic around checking for `content_normalized`