### PR TITLE
Release 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 3.3.1
+
+2021-10-07
+
+### Fixed
+
+- Fix evaluation of peer dependencies with npm 7 (:tada: @manuelpuyol https://github.com/github/licensed/pull/411)
+
+### Changed
+
+- Manifest source evaluation performance improvements (https://github.com/github/licensed/pull/407)
+
 ## 3.3.0
 
 2021-09-18
@@ -509,4 +521,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/3.3.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/3.3.1...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "3.3.0".freeze
+  VERSION = "3.3.1".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 3.3.1

2021-10-07

### Fixed

- Fix evaluation of peer dependencies with npm 7 (:tada: @manuelpuyol https://github.com/github/licensed/pull/411)

### Changed

- Manifest source evaluation performance improvements (https://github.com/github/licensed/pull/407)