### PR TITLE
Replace Array#sum with Array#reduce

### DIFF
--- a/lib/licensed/reporters/status_reporter.rb
+++ b/lib/licensed/reporters/status_reporter.rb
@@ -49,7 +49,7 @@ module Licensed
         errored_reports = all_reports.select { |r| r.errors.any? }.to_a
 
         dependency_count = all_reports.count { |r| r.target.is_a?(Licensed::Dependency) }
-        error_count = errored_reports.sum { |r| r.errors.size }
+        error_count = errored_reports.reduce(0) { |count, r| count + r.errors.size }
 
         if error_count > 0
           shell.newline


### PR DESCRIPTION
Restores compatibility with Ruby 2.3 by replacing the `Array#sum` method that was introduced in Ruby 2.4. Fixes #413.

Not sure what the appetite is for maintaining legacy compatibility, but if it's worth releasing a new version for it, here's the fix.