### PR TITLE
Fix `nil` bug when there's no `dependency` key in `package.json`

### DIFF
--- a/lib/licensed/sources/npm.rb
+++ b/lib/licensed/sources/npm.rb
@@ -48,7 +48,7 @@ module Licensed
       end
 
       def packages
-        root_dependencies = package_metadata["dependencies"]
+        root_dependencies = package_metadata["dependencies"] || {}
         recursive_dependencies(root_dependencies).each_with_object({}) do |(name, results), hsh|
           results.uniq! { |package| package["version"] }
           if results.size == 1


### PR DESCRIPTION
I just have `devDependencies` in my project and I'm getting this error:

```
Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/sources/npm.rb:68:in 'Licensed::Sources::NPM#recursive_dependencies': undefined method 'each' for nil (NoMethodError)

        dependencies.each do |name, dependency|
                    ^^^^^
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/sources/npm.rb:52:in 'Licensed::Sources::NPM#packages'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/sources/npm.rb:31:in 'Licensed::Sources::NPM#enumerate_dependencies'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/sources/source.rb:102:in 'Licensed::Sources::Source#cached_dependencies'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/sources/source.rb:78:in 'Licensed::Sources::Source#dependencies'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:136:in 'Licensed::Commands::Command#run_source'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/cache.rb:55:in 'Licensed::Commands::Cache#run_source'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:101:in 'block (2 levels) in Licensed::Commands::Command#run_app'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:98:in 'Array#map'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:98:in 'block in Licensed::Commands::Command#run_app'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:95:in 'Dir.chdir'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:95:in 'Licensed::Commands::Command#run_app'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/cache.rb:41:in 'block in Licensed::Commands::Cache#run_app'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/cache.rb:167:in 'Licensed::Commands::Cache#with_licensee_configuration'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/cache.rb:40:in 'Licensed::Commands::Cache#run_app'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:67:in 'block in Licensed::Commands::Command#run_command'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:64:in 'Array#map'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:64:in 'Licensed::Commands::Command#run_command'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/cache.rb:24:in 'Licensed::Commands::Cache#run_command'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/commands/command.rb:23:in 'Licensed::Commands::Command#run'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/cli.rb:115:in 'Licensed::CLI#run'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/lib/licensed/cli.rb:18:in 'Licensed::CLI#cache'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/thor-1.3.2/lib/thor/command.rb:28:in 'Thor::Command#run'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/thor-1.3.2/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/thor-1.3.2/lib/thor.rb:538:in 'Thor.dispatch'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/thor-1.3.2/lib/thor/base.rb:584:in 'Thor::Base::ClassMethods#start'
	from /Users/koddsson/src/koddsson/console/vendor/bundle/ruby/3.4.0/gems/licensed-5.0.1/exe/licensed:5:in '<top (required)>'
	from bin/licensed:27:in 'Kernel#load'
	from bin/licensed:27:in '<main>'
```

This patch should fix it by defaulting to a empty hash if `dependencies` is `nil`.