### PR TITLE
Support pnpm v9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -368,7 +368,7 @@ jobs:
     needs: core
     strategy:
       matrix:
-        pnpm_version: [ 7 ]
+        pnpm_version: [ 7, 9 ]
     steps:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda

--- a/lib/licensed/sources/pnpm.rb
+++ b/lib/licensed/sources/pnpm.rb
@@ -18,19 +18,24 @@ module Licensed
       end
 
       def enumerate_dependencies
-        packages.map do |package|
-          name_with_version = "#{package["name"]}@#{package["version"]}"
-          Dependency.new(
-            name: name_with_version,
-            version: package["version"],
-            path: package["path"],
-            metadata: {
-              "type"     => PNPM.type,
-              "name"     => package["name"],
-              "summary"  => package["description"],
-              "homepage" => package["homepage"]
-            }
-          )
+        packages.flat_map do |package|
+          versions = package.key?("versions") ? package["versions"] : [package["version"]]
+          paths = package.key?("paths") ? package["paths"] : [package["path"]]
+
+          versions.zip(paths).map do |version, path|
+            name_with_version = "#{package["name"]}@#{version}"
+            Dependency.new(
+              name: name_with_version,
+              version: version,
+              path: path,
+              metadata: {
+                "type"     => PNPM.type,
+                "name"     => package["name"],
+                "summary"  => package["description"],
+                "homepage" => package["homepage"]
+              }
+            )
+          end
         end
       end
 


### PR DESCRIPTION
pnpm v9 has changed its license output format. The `version` and `path` keys have been replaced with `versions` and `paths`, respectively, which now store arrays.

This PR includes the following changes:

- Adds pnpm v9 to the test matrix.
- Supports the pnpm v9 format while remaining compatible with the previous format.

fixes #783 