### PR TITLE
Re-enable NuGet tests for .NET LTS versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,27 +290,26 @@ jobs:
     - name: Run tests
       run: script/test npm
 
-  # TODO: fix this and re-enable the tests.
-  # nuget:
-  #   runs-on: ubuntu-latest
-  #   needs: core
-  #   strategy:
-  #     matrix:
-  #       dotnet: [ '3.1.x', '5.x' ]
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Setup dotnet
-  #     uses: actions/setup-dotnet@v4.3.0
-  #     with:
-  #       dotnet-version: ${{ matrix.dotnet }}
-  #   - name: Set up Ruby
-  #     uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
-  #     with:
-  #       bundler-cache: true
-  #   - name: Set up fixtures
-  #     run: script/source-setup/nuget
-  #   - name: Run tests
-  #     run: script/test nuget
+  nuget:
+    runs-on: ubuntu-latest
+    needs: core
+    strategy:
+      matrix:
+        dotnet: [ '8.x', '10.x' ]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4.3.0
+      with:
+        dotnet-version: ${{ matrix.dotnet }}
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      with:
+        bundler-cache: true
+    - name: Set up fixtures
+      run: script/source-setup/nuget
+    - name: Run tests
+      run: script/test nuget
 
   pip:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR re-enables NuGet tests in the test matrix. Both .NET 3.x and 5.x are incompatible with Ubuntu 24.04 due to a libssl version mismatch (https://github.com/dotnet/core/issues/4749).

Because .NET 3.x and 5.x have reached the end of support, this PR updates the test matrix to use the current LTS version (8.x) and the next LTS version (10.x). These newer versions are compatible with Ubuntu 24.04.

Ref: https://dotnet.microsoft.com/en-us/download/dotnet