### PR TITLE
workflow: pin action versions and migrate archived actions

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
         with:
           bundler-cache: true
 

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -27,7 +27,7 @@ jobs:
           chmod 0600 $HOME/.gem/credentials
           gem build *.gemspec
 
-      - uses: github/licensed-ci@v1
+      - uses: licensee/licensed-ci@98eef7c23bcf8211e108781a9594e969da913e89 # v1.11.2
         with:
           # override the command to use licensed built from this repo
           command: bundle exec licensed

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+    - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
 
     - name: Build Gem
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Bower
       run: npm install -g bower
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler: ${{ matrix.bundler }}
         bundler-cache: true
@@ -53,7 +53,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Setup Haskell
@@ -81,7 +81,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Setup Rust toolchain
@@ -105,7 +105,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -127,7 +127,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -143,7 +143,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
@@ -165,7 +165,7 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
 
@@ -191,7 +191,7 @@ jobs:
         cache: true
         cache-dependency-path: test/fixtures/go/src/test/go.sum
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -213,7 +213,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up Java
@@ -237,7 +237,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Run tests
@@ -257,7 +257,7 @@ jobs:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -280,7 +280,7 @@ jobs:
         cache: npm
         cache-dependency-path: test/fixtures/npm/package-lock.json
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -301,7 +301,7 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -324,7 +324,7 @@ jobs:
         architecture: x64
         cache: pip
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
 
@@ -350,7 +350,7 @@ jobs:
         architecture: x64
         cache: pipenv
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
 
@@ -391,7 +391,7 @@ jobs:
           ${{ runner.os }}-pnpm-store-
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
 
@@ -413,7 +413,7 @@ jobs:
       with:
         swift-version: ${{ matrix.swift }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - uses: actions/cache@v4
@@ -448,7 +448,7 @@ jobs:
       env:
         YARN_VERSION: ${{ matrix.yarn_version }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -470,7 +470,7 @@ jobs:
     - name: Install Yarn
       run: npm install -g yarn
     - name: Set up Ruby
-      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
     - name: Set up fixtures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -225,7 +225,7 @@ jobs:
         distribution: adopt
         cache: gradle
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1
+      uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
       with:
         gradle-version: ${{ matrix.gradle }}
     - name: Bootstrap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
     - name: cache cabal dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: |
           ~/.cabal/packages
@@ -87,7 +87,7 @@ jobs:
     - name: Setup Rust toolchain
       run: rustup default stable
     - name: cache cargo dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: |
           ~/.cargo/registry
@@ -382,7 +382,7 @@ jobs:
       run: |
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       name: Setup pnpm cache
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -416,7 +416,7 @@ jobs:
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
-    - uses: actions/cache@v4
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       name: cache spm dependencies
       with:
         path: .build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,9 +85,7 @@ jobs:
       with:
         bundler-cache: true
     - name: Setup Rust toolchain
-      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-      with:
-        toolchain: stable
+      run: rustup default stable
     - name: cache cargo dependencies
       uses: actions/cache@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
       with:
         node-version: 18
     - name: Install Bower
@@ -57,7 +57,7 @@ jobs:
       with:
         bundler-cache: true
     - name: Setup Haskell
-      uses: haskell-actions/setup@bbd90a29996ac33b1c644a42206e312fc0379748
+      uses: haskell-actions/setup@bbd90a29996ac33b1c644a42206e312fc0379748 # v2.7.9
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
@@ -123,7 +123,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup php
-      uses: nanasess/setup-php@50c1c73e8ab7258f64ab525b05fcac481c0762db
+      uses: nanasess/setup-php@50c1c73e8ab7258f64ab525b05fcac481c0762db # v4.1.0
       with:
         php-version: ${{ matrix.php }}
     - name: Set up Ruby
@@ -161,7 +161,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: ${{ matrix.go }}
     - name: Set up Ruby
@@ -185,7 +185,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: ${{ matrix.go }}
         cache: true
@@ -217,7 +217,7 @@ jobs:
       with:
         bundler-cache: true
     - name: Set up Java
-      uses: actions/setup-java@v4.7.0
+      uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
       with:
         java-version: ${{ matrix.java }}
         distribution: adopt
@@ -252,7 +252,7 @@ jobs:
         elixir: [ 1.13.x, 1.14.x ]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451
+    - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451 # v1.18.2
       with:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}
@@ -274,7 +274,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
       with:
         node-version: ${{ matrix.node_version }}
         cache: npm
@@ -297,7 +297,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v4.3.0
+      uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Set up Ruby
@@ -318,7 +318,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ matrix.python }}
         architecture: x64
@@ -327,7 +327,6 @@ jobs:
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
-
     - name: Install virtualenv
       run: pip install virtualenv
     - name: Set up fixtures
@@ -344,7 +343,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ matrix.python }}
         architecture: x64
@@ -353,7 +352,6 @@ jobs:
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
-
     - name: Install pipenv
       run: pip install pipenv
     - name: Set up fixtures
@@ -369,19 +367,17 @@ jobs:
         pnpm_version: [ 7, 9 ]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+    - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       name: Install pnpm
       id: pnpm-install
       with:
         version: ${{ matrix.pnpm_version }}
         run_install: false
-
     - name: Get pnpm store directory
       id: pnpm-cache
       shell: bash
       run: |
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
     - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       name: Setup pnpm cache
       with:
@@ -389,12 +385,10 @@ jobs:
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
       with:
         bundler-cache: true
-
     - name: Set up fixtures
       run: script/source-setup/pnpm
     - name: Run tests
@@ -409,7 +403,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup Swift
-      uses: swift-actions/setup-swift@d4537ff835c9778c934e48f78639e270edd5839e
+      uses: swift-actions/setup-swift@d4537ff835c9778c934e48f78639e270edd5839e # v2.2.0
       with:
         swift-version: ${{ matrix.swift }}
     - name: Set up Ruby
@@ -438,7 +432,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
       with:
         node-version: 12
         cache: yarn
@@ -462,7 +456,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
       with:
         node-version: 12
         cache: yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup node
       uses: actions/setup-node@v4
       with:
@@ -33,7 +33,7 @@ jobs:
       matrix:
         bundler: [ '2.1', '2.2', '2.3', '2.4' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
       with:
@@ -51,7 +51,7 @@ jobs:
       matrix:
         ghc: [ '9.0', '9.2', '9.4' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
       with:
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
       with:
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
       with:
@@ -121,7 +121,7 @@ jobs:
       matrix:
         php: [ '7.4', '8.0' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup php
       uses: nanasess/setup-php@50c1c73e8ab7258f64ab525b05fcac481c0762db
       with:
@@ -141,7 +141,7 @@ jobs:
       matrix:
         ruby: [ '3.0', '3.1', '3.2' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
       with:
@@ -159,7 +159,7 @@ jobs:
       matrix:
         go: [ '1.17.x', '1.18.x', '1.19.x' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup go
       uses: actions/setup-go@v5
       with:
@@ -183,7 +183,7 @@ jobs:
       matrix:
         go: [ '1.17.x', '1.18.x', '1.19.x' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup go
       uses: actions/setup-go@v5
       with:
@@ -211,7 +211,7 @@ jobs:
         java: [ '11' ]
         gradle: ['current', '7.6', '6.9.3']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
       with:
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
       uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
       with:
@@ -251,7 +251,7 @@ jobs:
         otp: [24.x, 25.x]
         elixir: [ 1.13.x, 1.14.x ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: erlef/setup-beam@5304e04ea2b355f03681464e683d92e3b2f18451
       with:
         otp-version: ${{matrix.otp}}
@@ -272,7 +272,7 @@ jobs:
       matrix:
         node_version: [ 14, 16, 18 ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup node
       uses: actions/setup-node@v4
       with:
@@ -295,7 +295,7 @@ jobs:
       matrix:
         dotnet: [ '8.x', '10.x' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4.3.0
       with:
@@ -316,7 +316,7 @@ jobs:
       matrix:
         python: [ '3.8', '3.9', '3.10' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup python
       uses: actions/setup-python@v5
       with:
@@ -342,7 +342,7 @@ jobs:
       matrix:
         python: [ '3.8', '3.10', '3.x' ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup python
       uses: actions/setup-python@v5
       with:
@@ -368,7 +368,7 @@ jobs:
       matrix:
         pnpm_version: [ 7, 9 ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
       name: Install pnpm
       id: pnpm-install
@@ -407,7 +407,7 @@ jobs:
       matrix:
         swift: [ "5.7", "5.6" ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup Swift
       uses: swift-actions/setup-swift@d4537ff835c9778c934e48f78639e270edd5839e
       with:
@@ -436,7 +436,7 @@ jobs:
         # not using 1.0.0 because it doesn't support `yarn list --production`
         yarn_version: [ 1.4.0, latest ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup node
       uses: actions/setup-node@v4
       with:
@@ -460,7 +460,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: core
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup node
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
This PR includes several improvements to the GitHub Actions workflows:

- Replace actions that are no longer maintained with alternatives:
  - Migrate `github/licensed-ci` to `licensee/licensed-ci` 😜 
  - Migrate `gradle/gradle-build-action` to `gradle/actions/setup-gradle`.
  - Migrate from `actions-rs/toolchain` to using the pre-installed `rustup` command([reference](https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-rust#specifying-a-rust-version)).
- Pin all external actions to commit hashes, with human-readable version comments.
  - I pined all actions regardless of creators, please let me know if it's intentional to pin `actions/*` to tags instead of commit hashes. It's also reasonable to do so to reduce dependency management cost if we trust `actions` organization.