### PR TITLE
Bump nokogiri from 1.18.3 to 1.18.4

### DIFF
--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.18.3
+version: 1.18.4
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       ruby2_keywords (>= 0.0.5)
     net-http (0.6.0)
       uri
-    nokogiri (1.18.3)
+    nokogiri (1.18.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (9.2.0)


### PR DESCRIPTION
Fix https://github.com/advisories/GHSA-3cgj-v3m4-cgcq and https://github.com/advisories/GHSA-g8fv-r98j-937r
ref: https://github.com/licensee/licensed/security/dependabot/25

closes #740 