### PR TITLE
build(deps): bump the all group with 3 updates

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      - uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
         with:
           bundler-cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+    - uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
 
     - name: Build Gem
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Bower
       run: npm install -g bower
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler: ${{ matrix.bundler }}
         bundler-cache: true
@@ -53,7 +53,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Setup Haskell
@@ -81,7 +81,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Setup Rust toolchain
@@ -105,7 +105,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -127,7 +127,7 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -143,7 +143,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
@@ -165,7 +165,7 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
 
@@ -191,7 +191,7 @@ jobs:
         cache: true
         cache-dependency-path: test/fixtures/go/src/test/go.sum
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -213,7 +213,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up Java
@@ -237,7 +237,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Run tests
@@ -257,7 +257,7 @@ jobs:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -280,7 +280,7 @@ jobs:
         cache: npm
         cache-dependency-path: test/fixtures/npm/package-lock.json
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -301,7 +301,7 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -324,7 +324,7 @@ jobs:
         architecture: x64
         cache: pip
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Install virtualenv
@@ -349,7 +349,7 @@ jobs:
         architecture: x64
         cache: pipenv
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Install pipenv
@@ -386,7 +386,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -408,7 +408,7 @@ jobs:
   #     with:
   #       swift-version: ${{ matrix.swift }}
   #   - name: Set up Ruby
-  #     uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+  #     uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
   #     with:
   #       bundler-cache: true
   #   - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -443,7 +443,7 @@ jobs:
       env:
         YARN_VERSION: ${{ matrix.yarn_version }}
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures
@@ -465,7 +465,7 @@ jobs:
     - name: Install Yarn
       run: npm install -g yarn
     - name: Set up Ruby
-      uses: ruby/setup-ruby@472790540115ce5bd69d399a020189a8c87d641f # v1.247.0
+      uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         bundler-cache: true
     - name: Set up fixtures

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 2.13.2
+version: 2.13.4
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday

--- a/.licenses/bundler/json.dep.yml
+++ b/.licenses/bundler/json.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: json
-version: 2.13.0
+version: 2.13.2
 type: bundler
 summary: JSON Implementation for Ruby
 homepage: https://github.com/ruby/json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     csv (3.3.5)
     dotenv (3.1.8)
     drb (2.2.3)
-    faraday (2.13.2)
+    faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -47,7 +47,7 @@ GEM
       net-http (>= 0.5.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    json (2.13.0)
+    json (2.13.2)
     language_server-protocol (3.17.0.5)
     licensee (9.18.0)
       dotenv (>= 2, < 4)
@@ -72,7 +72,7 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     parallel (1.27.0)
-    parser (3.3.8.0)
+    parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
     pathname-common_prefix (0.0.2)


### PR DESCRIPTION
Bumps the all group with 3 updates: [json](https://github.com/ruby/json), [faraday](https://github.com/lostisland/faraday) and [parser](https://github.com/whitequark/parser).

Updates `json` from 2.13.0 to 2.13.1
- [Release notes](https://github.com/ruby/json/releases)
- [Changelog](https://github.com/ruby/json/blob/master/CHANGES.md)
- [Commits](ruby/json@v2.13.0...v2.13.1)

Updates `faraday` from 2.13.2 to 2.13.4
- [Release notes](https://github.com/lostisland/faraday/releases)
- [Changelog](https://github.com/lostisland/faraday/blob/main/CHANGELOG.md)
- [Commits](lostisland/faraday@v2.13.2...v2.13.4)

Updates `parser` from 3.3.8.0 to 3.3.9.0
- [Changelog](https://github.com/whitequark/parser/blob/master/CHANGELOG.md)
- [Commits](whitequark/parser@v3.3.8.0...v3.3.9.0)
build(deps): bump ruby/setup-ruby in the all group

Bumps the all group with 1 update: [ruby/setup-ruby](https://github.com/ruby/setup-ruby).

Updates `ruby/setup-ruby` from 1.247.0 to 1.253.0
- [Release notes](https://github.com/ruby/setup-ruby/releases)
- [Changelog](https://github.com/ruby/setup-ruby/blob/master/release.rb)
- [Commits](ruby/setup-ruby@4727905...bb6434c)
