### PR TITLE
Infer version from git tags

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
         with:
@@ -27,6 +29,9 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           gem build *.gemspec
+
+      - name: Verify Gem Version
+        run: script/verify-gem-version
 
       - name: Set commit message
         id: commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
 
@@ -23,6 +25,9 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           gem build *.gemspec
+
+      - name: Verify Gem Version
+        run: script/verify-gem-version
 
       - name: Publish to GitHub Packages registry
         run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    licensed (5.0.6)
+    licensed (5.0.7)
       csv (~> 3.3)
       json (~> 2.6)
       licensee (~> 9.16)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To get started after checking out the repo, run
 
 You can also run `script/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then create a release on GitHub.
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, create a GitHub release from the matching `vX.Y.Z` tag.
 
 ### Adding a new source
 

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,56 @@
 # frozen_string_literal: true
+require "open3"
+
 module Licensed
-  VERSION = "5.0.6".freeze
+  VERSION = begin
+    root = File.expand_path("../..", __dir__)
+    loaded_spec = Gem.loaded_specs["licensed"]
+    loaded_from = loaded_spec&.loaded_from && File.expand_path(loaded_spec.loaded_from)
+
+    # Published gems should report the version stored in gem metadata. Source
+    # checkouts need to ignore Bundler's path gemspec so development builds can
+    # infer the next release version from git tags.
+    if loaded_spec&.version && loaded_from != File.join(root, "licensed.gemspec")
+      loaded_spec.version.to_s
+    else
+      git_error = nil
+
+      begin
+        output, status = Open3.capture2e(
+          "git",
+          "describe",
+          "--tags",
+          chdir: root
+        )
+      rescue SystemCallError => e
+        git_error = e.message
+      end
+
+      if status&.success?
+        described_version = output.strip.delete_prefix("v")
+
+        # Exact tags build that tag's version. Commits after a tag build the
+        # next patch version Homebrew and the release workflow should expect.
+        if (match = described_version.match(/\A(.+)-\d+-g[0-9a-f]+(?:-dirty)?\z/))
+          match[1].sub(/\d+\z/) { |segment| (segment.to_i + 1).to_s.rjust(segment.length, "0") }
+        else
+          described_version
+        end
+      elsif File.exist?(lockfile = File.join(root, "Gemfile.lock"))
+        # Shallow CI checkouts do not fetch tags in the broad test matrix. The
+        # lockfile keeps Bundler setup fast and deterministic there.
+        lockfile_version = File.read(lockfile)[/^    licensed \(([^)]+)\)$/, 1]
+        raise "Unable to determine licensed version from Gemfile.lock" unless lockfile_version
+
+        lockfile_version
+      else
+        error_output = output.to_s.strip
+        raise "Unable to determine licensed version" if git_error.to_s.empty? && error_output.empty?
+
+        raise "Unable to determine licensed version: #{git_error || error_output}"
+      end
+    end
+  end.freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first

--- a/script/verify-gem-version
+++ b/script/verify-gem-version
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+git_description="$(git describe --tags)"
+if [ -z "$git_description" ]; then
+  echo "Unable to determine git description from git tags." >&2
+  exit 1
+fi
+echo "Git describe: ${git_description}"
+
+expected_version="$(ruby -Ilib -rlicensed/version -e 'puts Licensed::VERSION')"
+if [ -z "$expected_version" ]; then
+  echo "Unable to determine expected version from licensed source." >&2
+  exit 1
+fi
+echo "Expected version: ${expected_version}"
+
+shopt -s nullglob
+gems=(licensed-*.gem)
+
+if [ "${#gems[@]}" -ne 1 ]; then
+  echo "Expected exactly one built licensed gem, found ${#gems[@]}." >&2
+  exit 1
+fi
+
+expected_gem="licensed-${expected_version}.gem"
+if [ "${gems[0]}" != "$expected_gem" ]; then
+  echo "Expected built gem ${expected_gem}, found ${gems[0]}." >&2
+  exit 1
+fi
+echo "Built gem: ${gems[0]}"
+
+gem_version="$(ruby -rrubygems/package -e 'puts Gem::Package.new(ARGV.fetch(0)).spec.version' "${gems[0]}")"
+if [ "$gem_version" != "$expected_version" ]; then
+  echo "Expected gem metadata version ${expected_version}, found ${gem_version}." >&2
+  exit 1
+fi
+echo "Gem metadata version: ${gem_version}"
+
+source_version="$(ruby -Ilib -rlicensed/version -e 'puts Licensed::VERSION')"
+if [ "$source_version" != "$expected_version" ]; then
+  echo "Expected source version ${expected_version}, found ${source_version}." >&2
+  exit 1
+fi
+echo "Source version: ${source_version}"

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -82,16 +82,19 @@ describe "licensed" do
   end
 
   describe "version" do
-    it "outputs VERSION constant" do
+    it "outputs the current licensed version" do
       expected_out = "#{Licensed::VERSION}\n"
-      out, = Open3.capture2 "bundle exec exe/licensed version"
-      assert_equal out, expected_out
+      out, status = Open3.capture2 "bundle exec exe/licensed version"
+      assert status.success?
+      assert_equal expected_out, out.lines.last
 
-      out, = Open3.capture2 "bundle exec exe/licensed -v"
-      assert_equal out, expected_out
+      out, status = Open3.capture2 "bundle exec exe/licensed -v"
+      assert status.success?
+      assert_equal expected_out, out.lines.last
 
-      out, = Open3.capture2 "bundle exec exe/licensed --version"
-      assert_equal out, expected_out
+      out, status = Open3.capture2 "bundle exec exe/licensed --version"
+      assert status.success?
+      assert_equal expected_out, out.lines.last
     end
   end
 

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+require "test_helper"
+require "fileutils"
+require "rbconfig"
+require "tmpdir"
+
+describe Licensed do
+  let(:root) { File.expand_path("..", __dir__) }
+
+  describe "VERSION" do
+    it "uses git describe when a gemspec version is not loaded" do
+      with_git_describe("v1.2.3") do |env|
+        out, status = ruby_output(env)
+
+        assert status.success?, out
+        assert_equal "1.2.3", out.strip
+      end
+    end
+
+    it "uses the next patch version when git describe is past the latest tag" do
+      with_git_describe("v1.2.3-4-gabc1234") do |env|
+        out, status = ruby_output(env)
+
+        assert status.success?, out
+        assert_equal "1.2.4", out.strip
+      end
+    end
+
+    it "uses the loaded gemspec version when available" do
+      out, status = ruby_output({ "PATH" => "" }, <<~RUBY)
+        Gem.loaded_specs["licensed"] = Gem::Specification.new do |spec|
+          spec.name = "licensed"
+          spec.version = "9.8.7"
+        end
+        require "licensed/version"
+        puts Licensed::VERSION
+      RUBY
+
+      assert status.success?, out
+      assert_equal "9.8.7", out.strip
+    end
+
+    it "uses Gemfile.lock when git describe is unavailable" do
+      with_git_describe("fatal: No names found", status: 128) do |env|
+        out, status = ruby_output(env)
+
+        assert status.success?, out
+        assert_equal File.read(File.join(root, "Gemfile.lock"))[/^    licensed \(([^)]+)\)$/, 1],
+                     out.strip
+      end
+    end
+
+    it "reports git describe errors" do
+      without_lockfile do |dir|
+        with_git_describe("fatal: No names found", status: 128) do |env|
+          out, status = ruby_output(env, nil, load_root: dir)
+
+          refute status.success?, out
+          assert_includes out,
+                          "Unable to determine licensed version: fatal: No names found"
+        end
+      end
+    end
+
+    it "reports when git is unavailable" do
+      without_lockfile do |dir|
+        out, status = ruby_output({ "PATH" => "" }, nil, load_root: dir)
+
+        refute status.success?, out
+        assert_includes out, "Unable to determine licensed version"
+        assert_includes out, "git"
+      end
+    end
+
+    it "uses git describe for the gemspec version" do
+      with_git_describe("v5.05") do |env|
+        out, status = ruby_output(env, <<~RUBY)
+          Dir.chdir(#{root.inspect}) do
+            puts Gem::Specification.load("licensed.gemspec").full_name
+          end
+        RUBY
+
+        assert status.success?, out
+        assert_equal "licensed-5.05", out.strip
+      end
+    end
+
+    it "uses the next patch version for the gemspec version" do
+      with_git_describe("v5.0.6-4-gabc1234") do |env|
+        out, status = ruby_output(env, <<~RUBY)
+          Dir.chdir(#{root.inspect}) do
+            puts Gem::Specification.load("licensed.gemspec").full_name
+          end
+        RUBY
+
+        assert status.success?, out
+        assert_equal "licensed-5.0.7", out.strip
+      end
+    end
+  end
+
+  def ruby_output(env = {}, code = nil, load_root: root)
+    if env.is_a?(String)
+      code = env
+      env = {}
+    end
+
+    Open3.capture2e(
+      {
+        "BUNDLE_BIN_PATH" => nil,
+        "BUNDLE_GEMFILE" => nil,
+        "BUNDLE_LOCKFILE" => nil,
+        "BUNDLER_SETUP" => nil,
+        "BUNDLER_VERSION" => nil,
+        "GEM_HOME" => nil,
+        "GEM_PATH" => nil,
+        "RUBYLIB" => nil,
+        "RUBYOPT" => nil
+      }.merge(env),
+      RbConfig.ruby,
+      "-I#{File.join(load_root, "lib")}",
+      "-e",
+      code || "require \"licensed/version\"; puts Licensed::VERSION"
+    )
+  end
+
+  def with_git_describe(version, status: 0)
+    Dir.mktmpdir do |dir|
+      git = File.join(dir, "git")
+      File.write(git, <<~SH)
+        #!/bin/sh
+        if [ "$1" = "describe" ]; then
+          printf '%s\\n' "#{version}"#{status.zero? ? "" : " >&2"}
+          exit #{status}
+        elif [ "$1" = "ls-files" ]; then
+          printf 'licensed.gemspec\\0lib/licensed/version.rb\\0exe/licensed\\0'
+        else
+          exit 1
+        fi
+      SH
+      File.chmod(0755, git)
+
+      yield "PATH" => "#{dir}:#{ENV["PATH"]}"
+    end
+  end
+
+  def without_lockfile
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p File.join(dir, "lib/licensed")
+      FileUtils.cp File.join(root, "lib/licensed/version.rb"),
+                   File.join(dir, "lib/licensed/version.rb")
+
+      yield dir
+    end
+  end
+end


### PR DESCRIPTION
- Avoid stale `VERSION` values causing gems to build with filenames that differ from the release tag.
- Let release builds set `LICENSED_VERSION` before publishing so the installed gem no longer needs `git`.
- Cover Homebrew's `licensed version` and gem filename expectations.